### PR TITLE
non existence imageId should throw exception that results in 404

### DIFF
--- a/src/main/java/example/dto/ImageResponseDTO.java
+++ b/src/main/java/example/dto/ImageResponseDTO.java
@@ -1,13 +1,17 @@
 package example.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@AllArgsConstructor
+@Builder(toBuilder = true)
 @Data
-@Builder
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ImageResponseDTO {
     Long id;

--- a/src/main/java/example/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/example/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,15 @@
+package example.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/example/services/ImageService.java
+++ b/src/main/java/example/services/ImageService.java
@@ -1,5 +1,6 @@
 package example.services;
 
+import example.exceptions.ResourceNotFoundException;
 import example.model.Image;
 import example.repositories.ImageRepository;
 import example.thirdparty.imagga.ImageDetector;
@@ -10,6 +11,7 @@ import org.springframework.util.ObjectUtils;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -33,7 +35,11 @@ public class ImageService {
     }
 
     public Image getImageById(Long id) {
-        return imageRepository.getReferenceById(id);
+        Optional<Image> optImage = imageRepository.findById(id);
+        if (optImage.isEmpty()) {
+            throw new ResourceNotFoundException(String.format("Image with id %d does not exist", id));
+        }
+        return optImage.get();
     }
 
     public Image add(Image image) throws IOException {

--- a/src/test/java/example/services/ImageServiceTest.java
+++ b/src/test/java/example/services/ImageServiceTest.java
@@ -12,11 +12,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOError;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class ImageServiceTest {
@@ -53,7 +53,7 @@ public class ImageServiceTest {
 
         // verify
         assertEquals(expectedImage, result, "Image objects are the same");
-        verify(imageRepository).save(any(Image.class));
+        verify(imageRepository, times(1)).save(any(Image.class));
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ImageServiceTest {
 
         // verify
         assertEquals(expectedImage, result, "Image objects are the same");
-        verify(imageRepository).save(any(Image.class));
+        verify(imageRepository, times(1)).save(any(Image.class));
     }
 
     @Test
@@ -117,7 +117,7 @@ public class ImageServiceTest {
         // verify
         assertEquals(expectedImage, result, "Image objects are the same");
         ArgumentCaptor<Image> captor = ArgumentCaptor.forClass(Image.class);
-        verify(imageRepository).save(captor.capture());
+        verify(imageRepository, times(1)).save(captor.capture());
         Image toBeSaved = captor.getValue();
         assertNotNull(toBeSaved.getLabel(), "label is not null");
     }
@@ -130,7 +130,7 @@ public class ImageServiceTest {
         // call the service
         List<Image> images = imageService.getAll();
 
-        verify(imageRepository).findAll();
+        verify(imageRepository, times(1)).findAll();
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ImageServiceTest {
         List<Image> images = imageService.getImagesWithObjects(List.of("cat", "dog"));
 
         // verify
-        verify(imageRepository).findContainingObject(eq(List.of("cat", "dog")));
+        verify(imageRepository, times(1)).findContainingObject(eq(List.of("cat", "dog")));
         assertEquals(1, images.size(), "number of elements result list");
         Image actual = images.get(0);
         assertEquals(expected, actual, "result is the correct image");
@@ -163,13 +163,13 @@ public class ImageServiceTest {
                 .objectDetection(true)
                 .objects(List.of("cat", "bird"))
                 .build();
-        when(imageRepository.getReferenceById(anyLong())).thenReturn(expected);
+        when(imageRepository.findById(anyLong())).thenReturn(Optional.of(expected));
 
         // call the service
         Image result = imageService.getImageById(1L);
 
         // verify
-        verify(imageRepository).getReferenceById(eq(1L));
+        verify(imageRepository, times(1)).findById(eq(1L));
         assertEquals(expected, result, "result is the correct image");
     }
 }


### PR DESCRIPTION
```repository.getReferenceById()``` returns a Hibernate proxy and is not the right method to call.

Replacing that with ```repository.findById()```

Also throw an exception when an image Id does not exist. 

Annotate the exception with 404.